### PR TITLE
correct copying of language string in find_language

### DIFF
--- a/cld3/cld3.cc
+++ b/cld3/cld3.cc
@@ -20,9 +20,8 @@ const Result find_language(CLanguageIdentifier li, char *data, int length) {
   std::string text(data, length);
   const NNetLanguageIdentifier::Result res = lang_id->FindLanguage(text);
   Result out;
-  // These strings are statically allocated, so we can do this c_str() without
-  // worrying about them going off the stack.
-  out.language = res.language.c_str();
+  out.language = new char[res.language.length() + 1];
+  strcpy(out.language, res.language.c_str());
   out.len_language = res.language.length();
   out.probability = res.probability;
   out.is_reliable = res.is_reliable;

--- a/cld3/cld3.h
+++ b/cld3/cld3.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
   typedef struct {
-    const char* language;
+    char* language;
     int len_language;
     float probability; // Language probability.
     bool is_reliable;  // Whether the prediction is reliable.


### PR DESCRIPTION
We might just want to hack cld3 itself to give us the language_id int and bubble it up for Go to do the static lookups instead of copying these tiny strings multiple times.

Fixes #4